### PR TITLE
Accept differently-ordered arrays

### DIFF
--- a/specs/make_better_change_spec.rb
+++ b/specs/make_better_change_spec.rb
@@ -1,13 +1,13 @@
 describe "Make better change" do
   it "Returns the smallest possible array of coins: case 1" do
-    expect(make_better_change(24, [10,7,1])).to eq([10,7,7])
+    expect(make_better_change(24, [10,7,1])).to match_array([10,7,7])
   end
 
   it "Returns the smallest possible array of coins: case 2" do
-    expect(make_better_change(25, [10,7,1])).to eq([10,7,7,1])
+    expect(make_better_change(25, [10,7,1])).to match_array([10,7,7,1])
   end
 
   it "Returns the smallest possible array of coins: case 3" do
-    expect(make_better_change(25, [10,8,7,1])).to eq([10,8,7])
+    expect(make_better_change(25, [10,8,7,1])).to match_array([10,8,7])
   end
 end

--- a/specs/permutations_spec.rb
+++ b/specs/permutations_spec.rb
@@ -1,5 +1,5 @@
 describe "#permutations" do
   it "returns all permutations of an array" do
-    expect(permutations([1, 2, 3])).to eq([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]])
+    expect(permutations([1, 2, 3])).to match_array([[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]])
   end
 end

--- a/specs/real_words_in_string_spec.rb
+++ b/specs/real_words_in_string_spec.rb
@@ -12,6 +12,6 @@ describe "real_words_in_string" do
   it "finds words within words" do
     dictionary = ["bears", "ear", "a", "army"]
     words = "erbearsweatmyajs".real_words_in_string(dictionary)
-    expect(words).to eq(["bears", "ear", "a"])
+    expect(words).to match_array(["bears", "ear", "a"])
   end
 end

--- a/specs/subsets_spec.rb
+++ b/specs/subsets_spec.rb
@@ -1,7 +1,7 @@
 describe 'subsets' do
 
   it "Correctly returns all subsets of an array" do
-    expect(subsets([1, 2, 3])).to eq([[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]])
+    expect(subsets([1, 2, 3])).to match_array([[], [1], [2], [1, 2], [3], [1, 3], [2, 3], [1, 2, 3]])
   end
 
 end


### PR DESCRIPTION
Using match_array instead of eq for some problems (where ordering doesn't matter) should prevent

expected: [[1, 2, 3], [1, 3, 2], [2, 1, 3], [2, 3, 1], [3, 1, 2], [3, 2, 1]]
got: [[1, 2, 3], [2, 1, 3], [2, 3, 1], [1, 3, 2], [3, 1, 2], [3, 2, 1]]
