### PR TITLE
Fix redundant definition

### DIFF
--- a/problems/bubble_sort.rb
+++ b/problems/bubble_sort.rb
@@ -1,7 +1,4 @@
 class Array
-  def bubble_sort!
-  end
-
   def bubble_sort!(&prc)
   end
 


### PR DESCRIPTION
Since 'bubble_sort!' and 'bubble_sort!(&prc)' share the same signature, the second definition overwrites the first. The function already needs to check whether it's been passed a block.